### PR TITLE
feat: add OGP preview for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ The original template can be found here.
 
 @lekoarts/gatsby-theme-minimal-blog.\
 https://github.com/LekoArts/gatsby-themes/tree/main/themes/gatsby-theme-minimal-blog
+
+## OGP previews
+
+Add the title "ogp" to a Markdown link to render an OGP card instead of a regular link:
+
+```
+[Example](https://example.com "ogp")
+```
+

--- a/src/@lekoarts/gatsby-theme-minimal-blog/components/mdx-components.tsx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/components/mdx-components.tsx
@@ -8,7 +8,8 @@ import OgpLink from "./ogp-link"
 const MdxComponents = {
   Text: (props: any) => <Text {...props} />,
   Title: (props: any) => <Title {...props} />,
-  a: (props: any) => <OgpLink {...props} />,
+  a: ({ title, ...rest }: any) =>
+    title === "ogp" ? <OgpLink {...rest} /> : <a title={title} {...rest} />,
   pre: (preProps: any) => {
     const props = preToCodeBlock(preProps)
     if (props) {

--- a/src/@lekoarts/gatsby-theme-minimal-blog/components/mdx-components.tsx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/components/mdx-components.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import { Text } from "theme-ui"
+import { preToCodeBlock } from "@lekoarts/themes-utils"
+import Code from "@lekoarts/gatsby-theme-minimal-blog/src/components/code"
+import Title from "@lekoarts/gatsby-theme-minimal-blog/src/components/title"
+import OgpLink from "./ogp-link"
+
+const MdxComponents = {
+  Text: (props: any) => <Text {...props} />,
+  Title: (props: any) => <Title {...props} />,
+  a: (props: any) => <OgpLink {...props} />,
+  pre: (preProps: any) => {
+    const props = preToCodeBlock(preProps)
+    if (props) {
+      return <Code {...props} />
+    }
+    return <pre {...preProps} />
+  },
+}
+
+export default MdxComponents

--- a/src/@lekoarts/gatsby-theme-minimal-blog/components/ogp-link.tsx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/components/ogp-link.tsx
@@ -1,0 +1,78 @@
+import * as React from "react"
+
+interface OgpData {
+  title?: string
+  description?: string
+  image?: string
+}
+
+const fetchOgp = async (url: string): Promise<OgpData> => {
+  try {
+    const target = url.replace(/^https?:\/\//, "")
+    const res = await fetch(`https://r.jina.ai/https://${target}`)
+    const html = await res.text()
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(html, "text/html")
+    const getMeta = (prop: string) =>
+      doc.querySelector(`meta[property='${prop}']`)?.getAttribute("content") ||
+      doc.querySelector(`meta[name='${prop}']`)?.getAttribute("content")
+
+    return {
+      title: getMeta("og:title") || doc.title,
+      description: getMeta("og:description") || undefined,
+      image: getMeta("og:image") || undefined,
+    }
+  } catch (e) {
+    console.error(e)
+    return {}
+  }
+}
+
+const OgpLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({ href, children, ...rest }) => {
+  const [ogp, setOgp] = React.useState<OgpData | null>(null)
+
+  React.useEffect(() => {
+    if (!href || !/^https?:/.test(href)) return
+    fetchOgp(href).then(setOgp)
+  }, [href])
+
+  if (!href || !/^https?:/.test(href) || !ogp) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid #ccc",
+        borderRadius: "4px",
+        textDecoration: "none",
+        color: "inherit",
+        maxWidth: "500px",
+        margin: "1rem 0",
+      }}
+      {...rest}
+    >
+      {ogp.image && (
+        <img
+          src={ogp.image}
+          alt={ogp.title || href}
+          style={{ width: "100%", maxHeight: "260px", objectFit: "cover", borderRadius: "4px 4px 0 0" }}
+        />
+      )}
+      <div style={{ padding: "8px" }}>
+        <strong>{ogp.title || href}</strong>
+        {ogp.description && <p style={{ margin: "4px 0 0" }}>{ogp.description}</p>}
+      </div>
+    </a>
+  )
+}
+
+export default OgpLink

--- a/src/@lekoarts/gatsby-theme-minimal-blog/components/ogp-link.tsx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/components/ogp-link.tsx
@@ -8,8 +8,7 @@ interface OgpData {
 
 const fetchOgp = async (url: string): Promise<OgpData> => {
   try {
-    const target = url.replace(/^https?:\/\//, "")
-    const res = await fetch(`https://r.jina.ai/https://${target}`)
+    const res = await fetch(`https://r.jina.ai/${url}`)
     const html = await res.text()
     const parser = new DOMParser()
     const doc = parser.parseFromString(html, "text/html")


### PR DESCRIPTION
## Summary
- show OGP card for external links using a custom `OgpLink` component
- render the card automatically for MDX `<a>` tags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689777d761f883328e2335e46b616ecc